### PR TITLE
Updated elm to 0.19.1 Release

### DIFF
--- a/Formula/elm.rb
+++ b/Formula/elm.rb
@@ -5,8 +5,8 @@ class Elm < Formula
 
   desc "Functional programming language for building browser-based GUIs"
   homepage "https://elm-lang.org"
-  url "https://github.com/elm/compiler/archive/0.19.0.tar.gz"
-  sha256 "494df33724224307d6e2b4d0b342448cc927901483384ee4f8cfee2cb38e993c"
+  url "https://github.com/elm/compiler/archive/0.19.1.tar.gz"
+  sha256 "aa161caca775cef1bbb04bcdeb4471d3aabcf87b6d9d9d5b0d62d3052e8250b1"
 
   bottle do
     cellar :any_skip_relocation
@@ -39,18 +39,18 @@ class Elm < Formula
         "source-directories": [
                   "."
         ],
-        "elm-version": "0.19.0",
+        "elm-version": "0.19.0 <= v < 0.20.0",
         "dependencies": {
                 "direct": {
-                    "elm/browser": "1.0.0",
-                    "elm/core": "1.0.0",
-                    "elm/html": "1.0.0"
+                    "elm/browser": "1.0.0 <= v < 2.0.0",
+                    "elm/core": "1.0.0 <= v < 2.0.0",
+                    "elm/html": "1.0.0 <= v < 2.0.0"
                 },
                 "indirect": {
-                    "elm/json": "1.0.0",
-                    "elm/time": "1.0.0",
-                    "elm/url": "1.0.0",
-                    "elm/virtual-dom": "1.0.0"
+                    "elm/json": "1.0.0 <= v < 2.0.0",
+                    "elm/time": "1.0.0 <= v < 2.0.0",
+                    "elm/url": "1.0.0 <= v < 2.0.0",
+                    "elm/virtual-dom": "1.0.2 <= v < 2.0.0"
                 }
         },
         "test-dependencies": {


### PR DESCRIPTION
Updated the elm language to latest 0.19.1 release. The current version is still older 0.19.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
-----
